### PR TITLE
Fixed shebang

### DIFF
--- a/EtherScanDB/generateTagPack.py
+++ b/EtherScanDB/generateTagPack.py
@@ -1,5 +1,5 @@
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*- 
-#!/usr/bin/pyhton3
 
 import os
 import yaml

--- a/Ransomwhere/generateTagPack.py
+++ b/Ransomwhere/generateTagPack.py
@@ -1,5 +1,5 @@
+#!/usr/bin/env python3
 # -*- coding:utf-8 -*- 
-#!/usr/bin/pyhton3
 
 import os
 import json

--- a/SPLC Cryptocurrency Report/config.yaml
+++ b/SPLC Cryptocurrency Report/config.yaml
@@ -1,0 +1,7 @@
+RAW_FILE_NAME:     "splc_cryptocurrency_report.csv"
+TAGPACK_FILE_NAME: "splcccr_tagpack.yaml"
+URL:               "https://docs.google.com/spreadsheets/d/e/2PACX-1vQIGW0lif1LZA8JjEC8CSgDDRpHJctKiE-d87tqaiyEmcK-ygQC50ctK49e4I43tzxnv4Ej-w8l-0Y6/pub?output=csv"
+SOURCE:            "https://www.splcenter.org/cryptocurrency-report"
+TITLE:             "SPLC Cryptocurrency Report"
+CREATOR:           "Southern Poverty Law Center"
+DESCRIPTION:       "The extreme far right’s early embrace of cryptocurrencies such as Bitcoin and Monero has allowed them to expand their movement and to obscure funding sources. Hatewatch has compiled an extensive list of cryptocurrency addresses used by extremists to solicit donations and conduct other business. This list below is updated periodically as new donation addresses are located."

--- a/SPLC Cryptocurrency Report/generateTagPack.py
+++ b/SPLC Cryptocurrency Report/generateTagPack.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Convert Southern Poverty Law Center Cryptocurrency Report to a TagPack.
+"""
+
+import os
+import csv
+from datetime import datetime
+from typing import List
+
+import yaml
+
+
+CURRENCY = {
+    'Bitcoin Addresses': 'BTC',
+    'Ethereum Addresses': 'ETH',
+    'Litecoin Addresses': 'LTC',
+    'Monero Address': 'XMR'
+}
+
+
+class RawData:
+    """
+    Download and read data provided by the source.
+    """
+    def __init__(self, fn: str, url: str):
+        self.fn = fn
+        self.url = url
+
+    def download(self):
+        from urllib.request import urlretrieve
+        urlretrieve(self.url, self.fn)
+
+    def read(self) -> List[dict]:
+        with open(self.fn, 'r',encoding='utf-8', newline='') as csvfile:
+            reader = csv.DictReader(csvfile, delimiter=',', quotechar='"')
+            return [row for row in reader]
+
+
+class TagPackGenerator:
+    """
+    Generate a TagPack from SPLC Cryptocurrency Report.
+    """
+
+    def __init__(self, rows: List[dict], title: str, creator: str, description: str, lastmod: str, source: str):
+        self.rows = rows
+        self.data = {
+            'title': title,
+            'creator': creator,
+            'description': description,
+            'lastmod': lastmod,
+            'tags': []
+        }
+        self.source = source
+
+    def generate(self):
+        tags = []
+        for row in self.rows:
+            for column in ['Bitcoin Addresses', 'Ethereum Addresses', 'Litecoin Addresses', 'Monero Address']:
+                for address in row[column].split('\n'):
+                    if not address:
+                        continue
+                    tag = {
+                        'address': address,
+                        'currency': CURRENCY[column],
+                        'label': row['Entity'],
+                        'source': self.source,
+                        'category': 'User'  # like in the OFAC TagPack generator
+                    }
+                    tags.append(tag)
+        self.data['tags'] = tags
+
+    def saveYaml(self, fn: str):
+        with open(fn, 'w', encoding='utf-8') as f:
+            f.write(yaml.dump(self.data, sort_keys=False))
+
+
+if __name__ == '__main__':
+    with open('config.yaml', 'r') as config_file:
+        config = yaml.safe_load(config_file)
+
+    raw_data = RawData(config['RAW_FILE_NAME'], config['URL'])
+    if not os.path.exists(config['RAW_FILE_NAME']):
+        raw_data.download()
+
+    last_mod = datetime.fromtimestamp(os.path.getmtime(config['RAW_FILE_NAME'])).isoformat()
+    generator = TagPackGenerator(raw_data.read(), config['TITLE'], config['CREATOR'], config['DESCRIPTION'],
+                                 last_mod, config['SOURCE'])
+    generator.generate()
+    generator.saveYaml(config['TAGPACK_FILE_NAME'])


### PR DESCRIPTION
Three changes:

1. Fixed typo `pyhton3` to `python3`
2. Added `/usr/bin/env` in case Python3 interpreter is installed in a non-standard path
3. Moved shebang at the very top, as it should be